### PR TITLE
omit physical address line from validation email where no physical address provided

### DIFF
--- a/server/auth/signup.js
+++ b/server/auth/signup.js
@@ -107,12 +107,12 @@ const registerPendingSignup = async (body, hash, token) => {
 
 const sendValidationEmail = async (email, username, token) => {
 	const addr = `${process.env.WEB_PROTOCOL}://${process.env.WEB_ADDRESS}/auth/validation?username=${username}&token=${token}`;
-	const msg = `Hello ${username}!
-
-Please visit the following link to validate your account: ${addr}
-
-You can contact us directly at our physical mailing address here: ${process.env.MAIL_PHYSICAL}
-`;
+	const msg =
+  `Hello ${username}!\n\n` +
+  `Please visit the following link to validate your account: ${addr}\n` +
+  (process.env.MAIL_PHYSICAL
+    ? `\nYou can contact us directly at our physical mailing address here: ${process.env.MAIL_PHYSICAL}\n`
+    : ``);
 
 	let transporter, info;
 


### PR DESCRIPTION
Per issue #8 

Removes the physical address line from the welcome email during signup.
Additionally -- changed the message to use `\n` and concatenation to be more readable.  It was fine how it was initially, but adding the logic to check the presence of the physical address made it quite unreadable.